### PR TITLE
fix(sh): fix broken stderr handling and add unit tests

### DIFF
--- a/history/69c81fd0-feature-sh-unit-tests/INITIATIVE.md
+++ b/history/69c81fd0-feature-sh-unit-tests/INITIATIVE.md
@@ -1,0 +1,43 @@
+# Initiative: sh-unit-tests
+
+**Type**: feature
+**Status**: completed
+**Created**: 2026-03-28
+**ID**: 69c81fd0-feature-sh-unit-tests
+
+## Steps
+
+| Step | Status | Updated |
+|------|--------|--------|
+| spec | completed | 2026-03-28 11:37 |
+| plan | completed | 2026-03-28 11:42 |
+| tasks | completed | 2026-03-28 11:45 |
+| implement | completed | 2026-03-28 11:48 |
+
+## Source
+
+**Linear Ticket**: [DEV-162](https://linear.app/heinsight/issue/DEV-162/add-unit-tests-for-pkgsh-shell-execution)
+**Title**: Add unit tests for pkg/sh (shell execution)
+
+## Description
+
+<!-- Add a description of this initiative -->
+
+## Goals
+
+<!-- Define the goals for this initiative -->
+
+## Progress
+
+<!-- Track progress here -->
+
+## Completion
+
+**Completed**: 2026-03-28
+**Duration**: Same day
+
+### Outcomes
+- Bug fix: Fixed `RunWithWriters` — stdOut never assigned, errOut nil-check inverted
+- Bug fix: Fixed `Run` — `c.Stderr` was set to `e.stdOut` instead of `e.stdErr`
+- Feature: Added 26 unit tests covering all 15 exported symbols in pkg/sh
+- All existing tests pass (no regressions)

--- a/history/69c81fd0-feature-sh-unit-tests/implementation-plan.md
+++ b/history/69c81fd0-feature-sh-unit-tests/implementation-plan.md
@@ -1,0 +1,116 @@
+# Implementation Plan: pkg/sh Unit Tests
+
+## Overview
+
+Two deliverables: (1) fix the `RunWithWriters` bug, (2) add comprehensive unit tests for all exported functions in `pkg/sh`.
+
+## Step 1: Fix RunWithWriters Bug
+
+**File**: `pkg/sh/sh.go` (lines 120-128)
+
+Current (broken):
+```go
+func (e *Executor) RunWithWriters(stdOut, errOut io.Writer) error {
+    if stdOut == nil {
+        stdOut = os.Stdout
+    }
+    if errOut == nil {
+        e.stdErr = errOut  // assigns nil to stdErr
+    }
+    return e.Run()
+}
+```
+
+Fixed:
+```go
+func (e *Executor) RunWithWriters(stdOut, errOut io.Writer) error {
+    if stdOut == nil {
+        stdOut = os.Stdout
+    }
+    if errOut == nil {
+        errOut = os.Stderr
+    }
+    e.stdOut = stdOut
+    e.stdErr = errOut
+    return e.Run()
+}
+```
+
+**Changes**:
+- Assign `stdOut` param to `e.stdOut` (was never assigned)
+- Fix `errOut` nil-check: default to `os.Stderr`, not assign nil
+- Assign `errOut` param to `e.stdErr`
+
+**Dependency**: None. Do this first so tests can verify correct behavior.
+
+## Step 2: Create Test File
+
+**File**: `pkg/sh/sh_test.go`
+
+**Structure**: Single `ShTestSuite` using `testify/suite`.
+
+### Test Groups (in order of implementation):
+
+#### Group A: EnvMapToEnv (pure function, no side effects)
+- `TestEnvMapToEnv_WithEntries` — verify KEY=VALUE formatting
+- `TestEnvMapToEnv_Empty` — verify empty map returns nil
+
+#### Group B: Constructor Functions
+- `TestCmd_NoArgs` — `Cmd()` creates executor with empty command
+- `TestCmd_SingleArg` — `Cmd("echo")` sets cmd field
+- `TestCmd_MultipleArgs` — `Cmd("echo", "hello")` sets cmd and args
+- `TestCmdWithCtx` — verify context is propagated
+
+#### Group C: Builder Methods
+- `TestDir` — set working dir, run `pwd`, verify output
+- `TestSetArgs` — set args on existing executor
+- `TestSetEnv` — replace environment entirely
+- `TestAddEnv` — append to environment
+- `TestStdin` — pipe input via `strings.NewReader`, read with `cat`
+
+#### Group D: Command Parsing
+- `TestRun_SingleStringWithSpaces` — `Cmd("echo hello")` parses correctly
+- `TestRun_VariadicArgs` — `Cmd("echo", "hello")` uses args directly
+- `TestRun_CommandWithSpacesAndSetArgs` — parsed cmd parts + SetArgs combine
+
+#### Group E: Execution & Output Capture
+- `TestRun_Success` — `Cmd("true").Run()` returns nil
+- `TestRun_Failure` — `Cmd("false").Run()` returns error
+- `TestStdOut` — captures stdout only
+- `TestString` — captures combined stdout+stderr
+- `TestRunWithWriters` — custom writers receive output
+- `TestRunWithWriters_NilDefaults` — nil writers default to os.Stdout/Stderr
+- `TestRunAndStream` — runs without error (output goes to os.Stdout/Stderr)
+
+#### Group F: Context Cancellation
+- `TestCmdWithCtx_Cancellation` — cancelled context terminates command
+
+#### Group G: DetermineWidth
+- `TestDetermineWidth_NotTerminal` — returns -1 in test environment
+
+#### Group H: Edge Cases
+- `TestRun_NonExistentDir` — Dir set to invalid path returns error
+- `TestRun_EmptyCommand` — empty Cmd() returns error
+- `TestSetPrintFinalCommand` — verify flag can be set (execution test)
+
+## Step 3: Run Tests
+
+```
+go test -v -count=1 ./pkg/sh/...
+```
+
+Verify all pass, no flaky tests from timing-dependent operations.
+
+## Dependencies
+
+```
+Step 1 (bug fix) → Step 2 (tests) → Step 3 (verify)
+```
+
+Step 2 Group A-C have no interdependencies and could be written in any order. Groups D-H depend on basic execution working (Group E).
+
+## Risk Assessment
+
+- **Low risk**: All tests use deterministic commands (`echo`, `true`, `false`, `cat`, `pwd`)
+- **Context cancellation test**: Uses `sleep` with short timeout — keep timeout generous enough to avoid flakiness (100ms+ for cancellation)
+- **Platform**: Tests use Unix commands — should work on macOS and Linux (CI)

--- a/history/69c81fd0-feature-sh-unit-tests/research.md
+++ b/history/69c81fd0-feature-sh-unit-tests/research.md
@@ -1,0 +1,68 @@
+---
+status: complete
+updated: 2026-03-28
+---
+
+# Research: pkg/sh Unit Tests
+
+## Executive Summary
+
+`pkg/sh` is a 2-file, ~215 LOC shell execution package with 15 exported symbols and zero test coverage. It's used throughout the codebase as the primary execution layer. The project uses testify/suite v1.9.0 for testing, and the package's builder pattern with pure functions makes it highly testable.
+
+## Findings
+
+### Codebase Context
+
+- **Package structure**: Two files — `sh.go` (Executor builder + execution) and `info.go` (terminal width detection)
+- **Builder pattern**: All builder methods return `*Executor` for chaining. Terminal methods are `Run()`, `StdOut()`, `String()`, `RunAndStream()`, `RunWithWriters()`
+- **Command parsing**: When no args are provided and the command string contains spaces, `mvdan/sh/shell.Fields()` is used to parse the command. When args are provided and the command has spaces, it parses the command and prepends those parts to the existing args.
+- **Environment handling**: `CmdWithCtx` initializes env from `os.Environ()`. `SetEnv` replaces entirely, `AddEnv` appends.
+- **Consumers**: `pkg/gadgets`, `pkg/version`, `cmd/gogo/cmds/config.go`, `.gogo/pkg/git.go`, `.gogo/pkg/compile.go`, `gogo_cli_test.go`
+- **Usage patterns observed**: Single-string commands (`Cmd("go mod tidy")`), variadic args (`Cmd("go", "mod", "tidy")`), chained Dir+Run, StdOut capture, String capture, AddEnv with String
+- **Existing test style**: `pkg/version` uses testify/suite; `pkg/fs` uses table-driven tests with stdlib. Project rules mandate testify/suite + testify/assert.
+
+### Domain Knowledge
+
+- **Testing shell execution**: Use simple, deterministic commands (`echo`, `true`, `false`, `cat`) for unit tests
+- **Context cancellation**: Use `context.WithCancel` or `context.WithTimeout` plus `sleep` to verify cancellation
+- **Stdin piping**: Use `strings.NewReader` to inject stdin, verify with `cat`
+- **Environment testing**: Set unique env vars and echo them to verify propagation
+- **DetermineWidth**: Depends on real terminal via `golang.org/x/term` — in CI/test, stdout is typically not a TTY, so it returns -1. Testing the non-terminal path is reliable; testing the terminal path requires mocking or is best left to integration tests.
+
+### Bug Spotted During Research
+
+`RunWithWriters` has a likely bug on line 125-126 of sh.go:
+```go
+if errOut == nil {
+    e.stdErr = errOut  // sets stdErr to nil when errOut is nil
+}
+```
+This should probably be:
+```go
+if errOut != nil {
+    e.stdErr = errOut
+}
+```
+And the stdOut writer is never assigned to `e.stdOut`. The function sets local `stdOut` to `os.Stdout` if nil, but never passes it to the executor. Tests should document this behavior.
+
+## Decision Points
+
+- [x] **D1**: Use testify/suite (per project conventions)
+- [x] **D2**: Use real commands (`echo`, `true`, `false`, `cat`) rather than mock exec — the package wraps os/exec and tests should verify actual execution
+- [x] **D3**: Skip terminal-dependent DetermineWidth tests — CI has no TTY, test non-terminal path only
+- [x] **D4**: Fix the RunWithWriters bug in this ticket
+
+## Recommendations
+
+1. **Test file structure**: Single file `pkg/sh/sh_test.go` with a `ShTestSuite` using testify/suite
+2. **Use real commands**: `echo`, `true`, `false`, `cat`, `env` for deterministic, cross-platform-ish tests
+3. **Test DetermineWidth minimally**: Verify it returns -1 when not in a terminal (the CI case)
+4. **Document RunWithWriters bug**: Write a test that captures the current (broken) behavior, so the fix can be done in a follow-up
+
+## Sources
+
+- `pkg/sh/sh.go` — main executor implementation
+- `pkg/sh/info.go` — DetermineWidth
+- `pkg/version/version_test.go` — testify/suite pattern reference
+- `pkg/gadgets/builder_test.go` — test helper patterns
+- Linear DEV-162 — ticket requirements

--- a/history/69c81fd0-feature-sh-unit-tests/spec.md
+++ b/history/69c81fd0-feature-sh-unit-tests/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Unit Tests for pkg/sh
+
+**Feature Branch**: `morganhein/dev-162-add-unit-tests-for-pkgsh-shell-execution`
+**Created**: 2026-03-28
+**Status**: Draft
+**Input**: Linear DEV-162 — Add unit tests for pkg/sh (shell execution)
+
+## User Scenarios & Testing
+
+### User Story 1 - Basic Command Execution and Output Capture (Priority: P1)
+
+A developer runs commands via `sh.Cmd()` and captures output. Tests must verify that commands execute correctly and output is captured accurately via `StdOut()` and `String()`.
+
+**Why this priority**: This is the core functionality — if execution and output capture don't work, nothing else matters.
+
+**Independent Test**: Run `echo hello` via `Cmd("echo", "hello").StdOut()` and verify output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a simple command, **When** executed via `StdOut()`, **Then** stdout is captured as a string
+2. **Given** a simple command, **When** executed via `String()`, **Then** combined stdout+stderr is captured
+3. **Given** a failing command, **When** executed via `Run()`, **Then** a non-nil error is returned
+4. **Given** a successful command, **When** executed via `Run()`, **Then** nil error is returned
+
+---
+
+### User Story 2 - Command Parsing (Priority: P1)
+
+Commands can be specified as a single string with spaces (`Cmd("go mod tidy")`) or as variadic arguments (`Cmd("go", "mod", "tidy")`). The parser must handle both correctly.
+
+**Why this priority**: Two distinct code paths in `Run()` — both are heavily used throughout the codebase.
+
+**Independent Test**: Compare output of `Cmd("echo hello")` vs `Cmd("echo", "hello")`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a single string command with spaces, **When** executed, **Then** it is parsed and runs correctly
+2. **Given** variadic args, **When** executed, **Then** args are used as-is
+3. **Given** a command string with spaces AND SetArgs called, **When** executed, **Then** parsed command parts are prepended to SetArgs values
+
+---
+
+### User Story 3 - Builder Methods (Priority: P2)
+
+Builder methods (`Dir`, `SetArgs`, `SetEnv`, `AddEnv`, `Stdin`) configure the executor. Each must correctly influence execution.
+
+**Why this priority**: These are the most-used chainable methods in the codebase.
+
+**Independent Test**: Each builder method can be tested independently by verifying its effect on command execution.
+
+**Acceptance Scenarios**:
+
+1. **Given** `Dir(path)` is set, **When** command runs `pwd`, **Then** output matches the specified directory
+2. **Given** `SetArgs("hello")` is called on `Cmd("echo")`, **When** executed, **Then** output is "hello"
+3. **Given** `SetEnv` with a custom env, **When** command prints env, **Then** only custom env vars exist
+4. **Given** `AddEnv` with extra vars, **When** command prints a specific var, **Then** the added var is present
+5. **Given** `Stdin` with a reader, **When** `cat` reads from stdin, **Then** output matches input
+
+---
+
+### User Story 4 - Context Cancellation (Priority: P2)
+
+`CmdWithCtx` accepts a context for cancellation. A cancelled context must terminate the running command.
+
+**Why this priority**: Critical for timeout and graceful shutdown scenarios.
+
+**Independent Test**: Create a cancelled context, run a long-running command, verify it returns an error.
+
+**Acceptance Scenarios**:
+
+1. **Given** a context that is cancelled, **When** a long-running command is executed, **Then** Run() returns a context error
+2. **Given** a context with timeout, **When** command exceeds timeout, **Then** Run() returns an error
+
+---
+
+### User Story 5 - EnvMapToEnv Utility (Priority: P3)
+
+`EnvMapToEnv` converts `map[string]string` to `[]string` of `KEY=VALUE` pairs.
+
+**Why this priority**: Pure utility function, simple to test, lower risk.
+
+**Independent Test**: Pass a map, verify output slice contains expected `KEY=VALUE` entries.
+
+**Acceptance Scenarios**:
+
+1. **Given** a map with entries, **When** converted, **Then** output contains `KEY=VALUE` strings for each entry
+2. **Given** an empty map, **When** converted, **Then** output is nil/empty
+
+---
+
+### User Story 6 - DetermineWidth (Priority: P3)
+
+`DetermineWidth` returns the terminal width or -1 if not in a terminal.
+
+**Why this priority**: Simple function with limited testability in CI (no TTY).
+
+**Independent Test**: In a test environment (no TTY), verify it returns -1.
+
+**Acceptance Scenarios**:
+
+1. **Given** stdout is not a terminal (CI/test), **When** called, **Then** returns -1
+
+---
+
+### Edge Cases
+
+- What happens when `Cmd()` is called with no arguments? (empty command)
+- What happens when `Dir()` is set to a non-existent directory?
+- What happens when `SetEnv` is called with an empty slice?
+- How does command parsing handle quoted strings? (`Cmd("echo 'hello world'")`)
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Tests MUST cover `Cmd()` and `CmdWithCtx()` constructor functions
+- **FR-002**: Tests MUST verify output capture via `StdOut()` and `String()`
+- **FR-003**: Tests MUST verify builder methods: `Dir`, `SetArgs`, `SetEnv`, `AddEnv`, `Stdin`
+- **FR-004**: Tests MUST verify error propagation from failed commands
+- **FR-005**: Tests MUST verify context cancellation terminates execution
+- **FR-006**: Tests MUST verify command string parsing (single string with spaces)
+- **FR-007**: Tests MUST verify `EnvMapToEnv` key=value formatting
+- **FR-008**: Tests MUST verify `DetermineWidth` returns -1 when not in a terminal (skip TTY-dependent tests)
+- **FR-009**: Tests MUST verify combined args behavior (command with spaces + SetArgs)
+- **FR-010**: `RunWithWriters` MUST be fixed — stdOut writer must be assigned to executor, and errOut nil-check logic must be corrected
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: All exported functions in `pkg/sh` have at least one test
+- **SC-002**: Tests pass in CI (no terminal dependency)
+- **SC-003**: `go test ./pkg/sh/...` runs successfully with zero failures
+
+## Testing Requirements
+
+### Test Strategy
+
+- Single test file: `pkg/sh/sh_test.go`
+- Use `testify/suite` with a `ShTestSuite` struct (per project conventions)
+- Use real OS commands (`echo`, `true`, `false`, `cat`) for execution tests
+- Table-driven subtests where multiple inputs test the same behavior
+- No mocking of os/exec — tests verify actual shell execution
+
+### FR to Test Mapping
+
+| FR | Test Type | Description |
+|----|-----------|-------------|
+| FR-001 | Unit | Verify Cmd/CmdWithCtx create valid executors |
+| FR-002 | Unit | Verify StdOut/String capture command output |
+| FR-003 | Unit | Verify each builder method affects execution |
+| FR-004 | Unit | Verify failed commands return non-nil error |
+| FR-005 | Unit | Verify cancelled context stops command |
+| FR-006 | Unit | Verify space-separated string is parsed into cmd+args |
+| FR-007 | Unit | Verify EnvMapToEnv produces KEY=VALUE pairs |
+| FR-008 | Unit | Verify DetermineWidth returns -1 in non-TTY |
+| FR-009 | Unit | Verify parsed command parts + SetArgs combine correctly |
+
+### Edge Case Coverage
+
+- Empty command string -> test for error or specific behavior
+- Non-existent directory in Dir() -> test for error from Run()
+- Quoted strings in single-command parsing -> verify mvdan/sh parsing

--- a/history/69c81fd0-feature-sh-unit-tests/tasks.md
+++ b/history/69c81fd0-feature-sh-unit-tests/tasks.md
@@ -1,0 +1,77 @@
+# Tasks: pkg/sh Unit Tests
+
+**Complexity**: Simple (2 files, ~350 LOC)
+**Critical Path**: T001 → T002 → T003-T008 (parallel) → T009
+
+## Task List
+
+- [ ] T001 [US-] Fix RunWithWriters bug in `pkg/sh/sh.go` (lines 120-128)
+  - Assign stdOut param to e.stdOut
+  - Fix errOut nil-check to default to os.Stderr
+  - Assign errOut param to e.stdErr
+  - **Acceptance**: RunWithWriters correctly writes to provided writers
+
+- [ ] T002 [US-] Create test suite scaffold in `pkg/sh/sh_test.go`
+  - ShTestSuite struct with testify/suite
+  - Suite runner function
+  - **Acceptance**: `go test ./pkg/sh/...` compiles and runs (0 tests)
+
+- [ ] T003 [P] [US5] Add EnvMapToEnv tests in `pkg/sh/sh_test.go`
+  - Test with entries → KEY=VALUE format
+  - Test empty map → nil/empty
+  - **Acceptance**: FR-007 covered
+
+- [ ] T004 [P] [US2,US3] Add constructor and builder method tests in `pkg/sh/sh_test.go`
+  - Cmd/CmdWithCtx constructors
+  - Dir, SetArgs, SetEnv, AddEnv, Stdin
+  - **Acceptance**: FR-001, FR-003 covered
+
+- [ ] T005 [P] [US2] Add command parsing tests in `pkg/sh/sh_test.go`
+  - Single string with spaces
+  - Variadic args
+  - Command with spaces + SetArgs
+  - **Acceptance**: FR-006, FR-009 covered
+
+- [ ] T006 [P] [US1] Add execution and output capture tests in `pkg/sh/sh_test.go`
+  - Run success/failure
+  - StdOut, String capture
+  - RunWithWriters with custom writers and nil defaults
+  - RunAndStream
+  - **Acceptance**: FR-002, FR-004, FR-010 covered
+
+- [ ] T007 [P] [US4] Add context cancellation test in `pkg/sh/sh_test.go`
+  - Cancelled context terminates command
+  - **Acceptance**: FR-005 covered
+
+- [ ] T008 [P] [US6] Add DetermineWidth and edge case tests in `pkg/sh/sh_test.go`
+  - DetermineWidth returns -1 in non-TTY
+  - Non-existent dir, empty command
+  - **Acceptance**: FR-008 covered
+
+- [ ] T009 [US-] Run tests and verify all pass
+  - `go test -v -count=1 ./pkg/sh/...`
+  - **Acceptance**: All tests pass, no flakiness
+
+## Dependency Graph
+
+```
+T001 (bug fix)
+  └─→ T002 (scaffold)
+        └─→ T003, T004, T005, T006, T007, T008 (parallel)
+              └─→ T009 (verify)
+```
+
+## FR Coverage
+
+| FR | Task(s) |
+|----|---------|
+| FR-001 | T004 |
+| FR-002 | T006 |
+| FR-003 | T004 |
+| FR-004 | T006 |
+| FR-005 | T007 |
+| FR-006 | T005 |
+| FR-007 | T003 |
+| FR-008 | T008 |
+| FR-009 | T005 |
+| FR-010 | T006 |

--- a/history/specs/01-workspace-setup.md
+++ b/history/specs/01-workspace-setup.md
@@ -1,0 +1,140 @@
+# Workspace Setup - Business Specification
+
+## Overview
+
+Workspace Setup enables developers to create a task workspace in any Go project with a single command. It scaffolds the folder structure, generates starter examples, and configures dependencies so that developers can write and run tasks immediately — no manual configuration required.
+
+## Capabilities Summary
+
+| Capability | Description | Priority |
+|------------|-------------|----------|
+| Initialize a workspace | Create a task folder with starter files | Core |
+| Generate example tasks | Provide working examples to learn from | Core |
+| Auto-configure dependencies | Set up module references automatically | Core |
+
+---
+
+## 1. Business Purpose
+
+### Problem Solved
+Starting a new task automation setup in a Go project requires creating folders, writing boilerplate, and configuring module dependencies. This is tedious and error-prone, especially for developers new to the tool.
+
+### Who Benefits
+- **Go Developers**: Get a working task setup in seconds instead of manually creating files and configuring dependencies.
+
+### Business Value
+Eliminates the friction of getting started. Developers can go from zero to running their first custom task in under a minute, which encourages adoption and consistent use of task automation across projects.
+
+---
+
+## 2. User Journey
+
+### Typical Workflow
+
+```
+1. Developer navigates to their Go project
+2. Developer runs the initialization command
+3. GoGo creates a task workspace folder (defaults to ".gogo")
+4. GoGo generates example task files showing common patterns
+5. GoGo configures module dependencies automatically
+6. Developer can immediately run the example tasks or start writing their own
+```
+
+### Common Scenarios
+
+| Scenario | Description | Outcome |
+|----------|-------------|---------|
+| New project setup | Developer wants to add task automation to a fresh Go project | Task workspace created with examples and dependencies ready |
+| Custom folder name | Developer wants the task folder named something other than the default | Workspace created in the specified folder |
+| Mage migration | Developer has existing Mage tasks and wants to try GoGo | GoGo recognizes Mage workspace folders, easing the transition |
+
+---
+
+## 3. What Users Provide
+
+### For Workspace Initialization
+- **Project location**: The developer must be inside a Go project (or module) directory
+- **Folder name** (optional): A custom name for the task workspace folder. Defaults to `.gogo` if not specified.
+
+---
+
+## 4. What Users Receive
+
+### Confirmations
+- Workspace folder is created in the project directory
+- Example task files are generated inside the workspace
+- Module dependencies are configured and resolved
+
+### Information
+- The developer can see the created files and immediately understand the expected structure by reading the examples
+
+---
+
+## 5. Business Rules
+
+| Rule | Description | Why It Exists |
+|------|-------------|---------------|
+| BR-001 | Workspace must be inside a Go module | Tasks are Go code and need a module context to compile |
+| BR-002 | Default folder name is `.gogo` | Convention keeps task files hidden and consistent across projects |
+| BR-003 | GoGo also recognizes `gogofiles` and `magefiles` folders | Supports migration from Mage and offers naming flexibility |
+| BR-004 | Dependencies are configured automatically | Developers should not need to manually wire up GoGo references |
+
+### Validation Rules
+- The target folder must not already exist (prevents overwriting existing work)
+- The project must be within a Go module (a `go.mod` file must be findable)
+
+---
+
+## 6. Error Scenarios
+
+| Situation | User Experience | Resolution |
+|-----------|-----------------|------------|
+| No Go module found | Developer is told they need to be in a Go module | Run `go mod init` first, then retry |
+| Folder already exists | Developer is informed the workspace folder already exists | Use the existing folder or choose a different name |
+
+### Common Issues
+- **Running outside a Go project**: GoGo needs a module context to work. Developer should initialize a Go module first.
+
+---
+
+## 7. Related Domains
+
+### Depends On
+- None — Workspace Setup is the entry point for all other domains
+
+### Used By
+- **Task Authoring**: Developers write tasks in the workspace that Setup creates
+- **Task Discovery**: Discovery searches for the workspace folder that Setup creates
+- **Task Execution**: Execution compiles and runs tasks from the workspace
+
+---
+
+## 8. Access Control
+
+GoGo is a local developer tool. All operations use the developer's file system permissions. There is no multi-user access model.
+
+---
+
+## 9. Lifecycle
+
+```
+No workspace → Initialized → Ready for task authoring
+```
+
+### State Definitions
+- **No workspace**: The project has no GoGo task folder yet
+- **Initialized**: The workspace folder, example files, and dependencies have been created
+- **Ready for task authoring**: The developer can start writing and running tasks
+
+### Transitions
+- No workspace → Initialized: Developer runs the initialization command
+- Initialized → Ready: Happens automatically — initialization produces a fully working workspace
+
+---
+
+## 10. Success Metrics
+
+| Metric | Target | Why It Matters |
+|--------|--------|----------------|
+| Time from command to first runnable task | Under 30 seconds | Fast setup encourages adoption |
+| Setup failures requiring manual intervention | Zero for standard Go projects | Reliability builds trust in the tool |

--- a/history/specs/02-task-authoring.md
+++ b/history/specs/02-task-authoring.md
@@ -1,0 +1,160 @@
+# Task Authoring - Business Specification
+
+## Overview
+
+Task Authoring is the core creative activity in GoGo. Developers write standard Go functions and GoGo automatically converts them into fully-featured CLI commands. Function names become command names, parameters become typed arguments, and comments become help text — no configuration files, decorators, or registration code needed.
+
+## Capabilities Summary
+
+| Capability | Description | Priority |
+|------------|-------------|----------|
+| Define a task as a function | Write an exported function that becomes a runnable command | Core |
+| Add typed arguments | Define parameters that become validated CLI arguments | Core |
+| Document tasks with comments | Add descriptions and help text through code comments | Core |
+| Signal success or failure | Indicate task outcomes through return values | Core |
+| Access task context | Use enriched context for argument metadata and constraints | Supporting |
+| Organize tasks across files | Split tasks into multiple files within the workspace | Supporting |
+
+---
+
+## 1. Business Purpose
+
+### Problem Solved
+Building CLI tools for project automation typically requires significant boilerplate: argument parsing, type validation, help text generation, and command registration. GoGo eliminates all of this by deriving the CLI interface directly from function signatures and comments.
+
+### Who Benefits
+- **Go Developers**: Write tasks as simple functions without learning a framework or writing boilerplate. The mental model is "write a function, run it as a command."
+
+### Business Value
+Dramatically lowers the cost of creating project automation. Tasks that would require dozens of lines of CLI setup code become single functions. This encourages teams to automate more and maintain their automation because the overhead is nearly zero.
+
+---
+
+## 2. User Journey
+
+### Typical Workflow
+
+```
+1. Developer creates a new file in the task workspace folder
+2. Developer writes an exported function with a descriptive name
+3. Developer adds parameters for any inputs the task needs
+4. Developer adds a comment above the function describing what it does
+5. The task is immediately available to run — no registration or configuration needed
+```
+
+### Common Scenarios
+
+| Scenario | Description | Outcome |
+|----------|-------------|---------|
+| Simple task, no arguments | Developer writes a function with no parameters | Task runs with just its name, no arguments needed |
+| Task with typed inputs | Developer adds text, number, or boolean parameters | Each parameter becomes a named, typed CLI argument |
+| Task that can fail | Developer returns an error when something goes wrong | GoGo reports the failure to the user with the error message |
+| Self-documenting task | Developer adds a comment above the function | Comment appears as description when browsing tasks |
+| Constrained arguments | Developer uses task context to set allowed values for an argument | GoGo validates input against the allowed values |
+
+---
+
+## 3. What Users Provide
+
+### For Defining a Task
+- **Function name**: Must start with an uppercase letter (Go convention for exported functions). The name becomes the command name.
+- **Parameters** (optional): Each parameter becomes a CLI argument. Supported types are text, whole numbers, decimal numbers, and true/false values.
+- **Comment** (optional): A comment above the function. The first line becomes the short description; additional lines become extended help text.
+
+### For Using Task Context
+- **Task context parameter**: Must be the first parameter if used. Provides access to argument metadata and configuration.
+- **Argument constraints** (optional): Developers can specify allowed values, default values, short flags, and help text for each argument through the context.
+
+---
+
+## 4. What Users Receive
+
+### Confirmations
+- When a task is authored correctly, it appears in the task listing immediately
+- When a task runs successfully, it exits cleanly
+- When a task fails, the error message is displayed clearly
+
+### Information
+- Developers see their function's comment as the task description
+- Developers see their parameters as documented, typed arguments in help output
+
+---
+
+## 5. Business Rules
+
+| Rule | Description | Why It Exists |
+|------|-------------|---------------|
+| BR-001 | Only exported functions become tasks | Convention separates public tasks from private helper functions |
+| BR-002 | Arguments must be simple types (text, numbers, true/false) | CLI arguments are inherently scalar — complex types cannot be passed on a command line |
+| BR-003 | Functions can only return nothing or an error | Tasks are actions, not data producers — they succeed or fail |
+| BR-004 | Task context must be the first parameter if used | Consistent convention makes parsing reliable |
+| BR-005 | Test files are ignored | Tasks in test files are for testing GoGo itself, not meant to be run as commands |
+| BR-006 | The first comment line is the short description | Provides concise listing text while allowing extended documentation |
+
+### Validation Rules
+- Function names must start with an uppercase letter
+- Parameters cannot be pointer types or complex structures
+- Only one error return value is allowed (no multiple returns)
+- Task context, if used, must be the first parameter
+
+---
+
+## 6. Error Scenarios
+
+| Situation | User Experience | Resolution |
+|-----------|-----------------|------------|
+| Function uses unsupported parameter types | Function is silently skipped — it won't appear as a task | Change parameters to supported simple types |
+| Function returns multiple values | Function is skipped | Change to return only an error or nothing |
+| Syntax error in task file | Build fails with a clear error message | Fix the syntax error in the source file |
+| Duplicate function names across files | Build fails due to naming conflict | Rename one of the conflicting functions |
+
+### Common Issues
+- **Task not appearing in listing**: The function is likely unexported (starts with lowercase) or uses unsupported parameter types. Check that the function name starts with an uppercase letter and all parameters are simple types.
+- **Unexpected argument behavior**: When using task context, ensure it is the first parameter and that argument names match the function parameters.
+
+---
+
+## 7. Related Domains
+
+### Depends On
+- **Workspace Setup**: Tasks are written in the workspace folder that Setup creates
+
+### Used By
+- **Task Discovery**: Discovery reads authored tasks to present listings and help text
+- **Task Execution**: Execution compiles and runs the authored tasks
+
+---
+
+## 8. Access Control
+
+All task authoring happens locally on the developer's machine. Any developer with file system access to the project can create, modify, or delete task files.
+
+---
+
+## 9. Lifecycle
+
+```
+Function written → Detected by GoGo → Available as command → Modified → Re-detected on next run
+```
+
+### State Definitions
+- **Written**: Developer has saved a function in the workspace
+- **Detected**: GoGo has parsed the function and validated its signature
+- **Available**: The task appears in listings and can be run
+- **Modified**: Developer has changed the function; cached binary is now stale
+
+### Transitions
+- Written → Detected: Happens automatically when GoGo parses the workspace
+- Detected → Available: Immediate — valid functions become available tasks
+- Available → Modified: Developer edits the source file
+- Modified → Detected: GoGo re-parses on next invocation
+
+---
+
+## 10. Success Metrics
+
+| Metric | Target | Why It Matters |
+|--------|--------|----------------|
+| Lines of code per task vs. traditional CLI setup | 80%+ reduction | Core value proposition — simplicity |
+| Time from writing a function to running it | Under 5 seconds (first run) | Instant feedback loop encourages authoring |
+| Functions rejected due to convention violations | Clear, actionable feedback | Developers should understand why a function isn't recognized |

--- a/history/specs/03-task-discovery.md
+++ b/history/specs/03-task-discovery.md
@@ -1,0 +1,136 @@
+# Task Discovery - Business Specification
+
+## Overview
+
+Task Discovery enables developers to browse, understand, and learn about all available tasks in a project without reading source code. GoGo presents a formatted, color-coded listing of tasks with descriptions and argument details, making it easy to find and understand the right task for the job.
+
+## Capabilities Summary
+
+| Capability | Description | Priority |
+|------------|-------------|----------|
+| List all available tasks | View formatted task listing with descriptions | Core |
+| View task arguments | See expected arguments with types and defaults | Core |
+| Discover from subdirectories | Find tasks from anywhere in the project tree | Core |
+| View version and build info | Check installed GoGo version and build details | Supporting |
+
+---
+
+## 1. Business Purpose
+
+### Problem Solved
+In projects with many automation tasks, developers need a quick way to find out what tasks exist, what they do, and how to invoke them — without digging through source files. Task Discovery provides this at-a-glance understanding.
+
+### Who Benefits
+- **Go Developers**: Quickly find the right task for a job, understand what arguments it expects, and see how to use it — all from the command line.
+
+### Business Value
+Reduces the time spent searching for and understanding automation tasks. New team members can immediately see what automation is available in a project, improving onboarding and reducing tribal knowledge dependencies.
+
+---
+
+## 2. User Journey
+
+### Typical Workflow
+
+```
+1. Developer runs GoGo without specifying a task
+2. GoGo searches for the nearest task workspace (current directory and parent directories)
+3. GoGo parses all task files in the workspace
+4. Developer sees a formatted list of tasks with short descriptions
+5. Developer identifies the task they need and sees its argument requirements
+```
+
+### Common Scenarios
+
+| Scenario | Description | Outcome |
+|----------|-------------|---------|
+| Browse all tasks | Developer runs GoGo with no arguments | Formatted list of all tasks with short descriptions |
+| Find tasks from a subdirectory | Developer is deep in the project tree | GoGo walks up the directory tree to find the workspace |
+| Check version | Developer wants to know which GoGo version is installed | Version number and build details displayed |
+
+---
+
+## 3. What Users Provide
+
+### For Listing Tasks
+- Nothing required — just run GoGo without arguments
+- **Source directory** (optional): Explicitly specify where to look for the task workspace
+
+---
+
+## 4. What Users Receive
+
+### Information
+- A color-coded, terminal-width-aware listing of all tasks
+- Each task shows its name and short description, aligned in columns
+- Task arguments are displayed with their names, types, and default values
+- Text wraps intelligently based on terminal width
+
+### Version Details
+- Version number and commit reference (compact format)
+- Detailed build information including build time, builder identity, and platform details
+
+---
+
+## 5. Business Rules
+
+| Rule | Description | Why It Exists |
+|------|-------------|---------------|
+| BR-001 | GoGo searches for workspaces by walking up the directory tree | Developers should not need to be in the workspace folder to discover tasks |
+| BR-002 | Search stops at the project root (version control boundary) | Prevents accidentally picking up tasks from unrelated parent projects |
+| BR-003 | Three folder names are recognized: `.gogo`, `gogofiles`, `magefiles` | Supports multiple conventions and Mage migration |
+| BR-004 | Task listing is formatted to fit the terminal width | Output remains readable regardless of terminal size |
+| BR-005 | Only the first line of a function comment becomes the short description | Keeps listings concise; full help available per-task |
+
+### Validation Rules
+- If no task workspace is found in the directory tree, the developer is informed clearly
+
+---
+
+## 6. Error Scenarios
+
+| Situation | User Experience | Resolution |
+|-----------|-----------------|------------|
+| No task workspace found | Developer sees a message indicating no tasks were found | Initialize a workspace or navigate to the correct project |
+| Task files have syntax errors | Build fails with an error pointing to the problematic file | Fix the syntax error in the indicated file |
+| Empty workspace | Task listing shows no tasks | Write some task functions in the workspace |
+
+### Common Issues
+- **Tasks not showing up**: The most common cause is functions that don't meet authoring conventions — unexported names or unsupported parameter types. See the Task Authoring specification.
+
+---
+
+## 7. Related Domains
+
+### Depends On
+- **Workspace Setup**: Discovery searches for the workspace folder that Setup creates
+- **Task Authoring**: Discovery reads and presents information from authored tasks
+
+### Used By
+- **Task Execution**: Developers typically discover a task first, then execute it
+
+---
+
+## 8. Access Control
+
+Task discovery is entirely local. Any developer who can access the project files can browse available tasks.
+
+---
+
+## 9. Lifecycle
+
+Task Discovery is stateless — it reads the current workspace state each time it runs. There is no persistent discovery state.
+
+```
+Developer invokes GoGo → Workspace found → Tasks parsed → Listing displayed
+```
+
+---
+
+## 10. Success Metrics
+
+| Metric | Target | Why It Matters |
+|--------|--------|----------------|
+| Time to display task listing | Under 1 second (cached) | Quick feedback keeps developers in flow |
+| Task descriptions visible without reading source | 100% of documented tasks | Whole point of discovery is avoiding source reading |
+| Workspace found from any project subdirectory | Always, if workspace exists | Convenience and reliability |

--- a/history/specs/04-task-execution.md
+++ b/history/specs/04-task-execution.md
@@ -1,0 +1,180 @@
+# Task Execution - Business Specification
+
+## Overview
+
+Task Execution is where GoGo delivers its core value — running developer-authored tasks instantly from the command line. GoGo compiles tasks into fast binaries, caches them intelligently to avoid unnecessary rebuilds, and provides options for pre-building and optimizing binaries. The developer experience is: name a task, pass arguments, get results.
+
+## Capabilities Summary
+
+| Capability | Description | Priority |
+|------------|-------------|----------|
+| Run a task with arguments | Execute any task by name with positional or named arguments | Core |
+| Smart caching | Reuse compiled binaries when source files haven't changed | Core |
+| Force rebuild | Bypass cache and recompile from scratch | Supporting |
+| Pre-build binaries | Compile tasks ahead of time for instant execution | Supporting |
+| Optimized builds | Create smaller binaries for distribution | Supporting |
+
+---
+
+## 1. Business Purpose
+
+### Problem Solved
+Developers need to run automation tasks quickly and reliably. Interpreted task runners add startup overhead; manually managing build artifacts is tedious. GoGo compiles tasks into native binaries for fast execution while handling all build management transparently.
+
+### Who Benefits
+- **Go Developers**: Run tasks as fast as native binaries with zero build management overhead. Repeated runs are instant thanks to caching.
+
+### Business Value
+Combines the convenience of scripting with the performance of compiled binaries. Smart caching means developers rarely wait for builds, and when they do, it's only because something actually changed.
+
+---
+
+## 2. User Journey
+
+### Typical Workflow
+
+```
+1. Developer specifies a task name and any required arguments
+2. GoGo locates the task workspace and parses task definitions
+3. GoGo checks if a cached binary exists and is up to date
+4. If cache is fresh, GoGo runs the cached binary immediately
+5. If cache is stale or missing, GoGo compiles a new binary
+6. The task runs with streaming output visible to the developer
+7. GoGo reports success or displays the error message from the task
+```
+
+### Common Scenarios
+
+| Scenario | Description | Outcome |
+|----------|-------------|---------|
+| First run | No cached binary exists yet | GoGo compiles and caches a binary, then runs it |
+| Repeated run, no changes | Source files unchanged since last build | Cached binary runs instantly — no compilation |
+| Run after editing a task | Source files are newer than the cached binary | GoGo recompiles automatically, then runs |
+| Forced rebuild | Developer wants a clean build regardless of cache state | Cache is bypassed and a fresh binary is compiled |
+| Pre-build for speed | Developer compiles ahead of time before a demo or CI run | Binary is ready; execution is instant |
+| Optimized build | Developer wants a smaller binary to share or deploy | Symbols and debug info are stripped for a compact binary |
+| Pass arguments by position | Developer provides values in order after the task name | Values are matched to parameters left-to-right |
+| Pass arguments by name | Developer uses named flags | Values are matched to the corresponding parameter |
+
+---
+
+## 3. What Users Provide
+
+### For Running a Task
+- **Task name**: The name of the task to run (matches the function name)
+- **Arguments** (if the task requires them): Values provided either positionally (in order) or as named flags
+
+### For Build Control
+- **Disable cache flag** (optional): Forces a fresh build regardless of cache state
+- **Keep artifacts flag** (optional): Preserves intermediate generated files for debugging
+- **Source directory** (optional): Explicitly specify where to find the task workspace
+- **Output path** (optional): Specify where to save a pre-built binary
+- **Optimize flag** (optional): Strip debug information for smaller binaries
+- **Verbose flag** (optional): Show detailed build and execution output
+
+---
+
+## 4. What Users Receive
+
+### Task Output
+- Real-time streaming output from the running task
+- The task's own printed output appears directly in the developer's terminal
+
+### Confirmations
+- Successful tasks exit cleanly with no extra messaging
+- Failed tasks display the error message returned by the task function
+
+### Build Artifacts (when requested)
+- Pre-built binary at the specified output path
+- Intermediate generated files preserved when keep-artifacts is enabled
+
+---
+
+## 5. Business Rules
+
+| Rule | Description | Why It Exists |
+|------|-------------|---------------|
+| BR-001 | Cached binaries are reused when all source files are older than the binary | Avoids unnecessary compilation for fast repeated execution |
+| BR-002 | Source file changes are detected by comparing file modification timestamps | Simple, reliable change detection without complex dependency tracking |
+| BR-003 | Both task source files and dependency files are checked for changes | Ensures the binary reflects all relevant source changes |
+| BR-004 | Cache is stored in a temporary directory keyed to the workspace | Each project gets its own cached binary without conflicts |
+| BR-005 | Arguments can be passed positionally or by name | Flexibility — quick invocations use positional; complex ones use named |
+| BR-006 | Type validation is applied to arguments before execution | Prevents runtime errors from mistyped arguments |
+
+### Validation Rules
+- Named task must exist in the workspace
+- Argument types must match what the task expects (text, number, decimal, true/false)
+- Required arguments must be provided (unless they have defaults)
+
+### Timing Rules
+- Compilation happens on-demand — only when the binary is missing or stale
+- Pre-building creates the binary ahead of time, so execution is immediate later
+
+---
+
+## 6. Error Scenarios
+
+| Situation | User Experience | Resolution |
+|-----------|-----------------|------------|
+| Task not found | Developer is told the task name doesn't match any known task | Check task name spelling and ensure the task is properly authored |
+| Wrong argument type | Developer sees a validation error (e.g., "expected a number") | Provide the argument in the correct type |
+| Missing required argument | Developer is told which argument is missing | Provide the missing argument |
+| Compilation failure | Build error is displayed with details | Fix the error in the task source code |
+| Task returns an error | Error message from the task is displayed | Address the issue described in the error message |
+
+### Common Issues
+- **Stale cache causing unexpected behavior**: Use the force-rebuild flag to ensure a fresh compilation.
+- **Slow first run**: Expected — the first run compiles the binary. Subsequent runs use the cache and are much faster.
+
+---
+
+## 7. Related Domains
+
+### Depends On
+- **Workspace Setup**: Execution needs a workspace to find task source files
+- **Task Authoring**: Execution compiles and runs authored tasks
+- **Task Discovery**: Developers typically discover tasks before executing them
+
+### Used By
+- None — Task Execution is the terminal domain in the workflow
+
+---
+
+## 8. Access Control
+
+Task execution is entirely local. Tasks run with the developer's own permissions and can do anything the developer could do manually (file operations, network calls, etc.). GoGo does not sandbox task execution.
+
+---
+
+## 9. Lifecycle
+
+```
+Task invoked → Cache checked → [Stale/Missing: Compile → Cache] → Execute → Report result
+```
+
+### State Definitions
+- **Invoked**: Developer has specified a task to run
+- **Cache checked**: GoGo compares source timestamps against the cached binary
+- **Compile**: Source is fresh or cache is bypassed — GoGo generates and compiles a new binary
+- **Cache**: New binary is stored for future reuse
+- **Execute**: The binary runs with the provided arguments
+- **Report result**: Success (clean exit) or failure (error message displayed)
+
+### Transitions
+- Invoked → Cache checked: Automatic on every run
+- Cache checked → Execute: Cache is fresh — skip compilation
+- Cache checked → Compile: Cache is stale or missing
+- Compile → Cache: New binary saved
+- Cache → Execute: Fresh binary runs
+- Execute → Report result: Task completes or fails
+
+---
+
+## 10. Success Metrics
+
+| Metric | Target | Why It Matters |
+|--------|--------|----------------|
+| Cached execution time | Near-instant (under 100ms overhead) | Developers shouldn't feel the tool's overhead |
+| Cache hit rate on unchanged source | 100% | Unnecessary rebuilds waste developer time |
+| Correct stale detection | 100% — always rebuild when source changes | Stale binaries cause subtle, confusing bugs |
+| Argument validation before execution | All type mismatches caught pre-run | Fail fast with a clear message, not a cryptic runtime error |

--- a/history/specs/README.md
+++ b/history/specs/README.md
@@ -1,0 +1,141 @@
+# GoGo - Business Specification
+
+## Overview
+
+GoGo is a task runner that lets Go developers write plain functions and instantly run them as command-line commands. Instead of building CLI boilerplate, argument parsing, and help text by hand, developers write ordinary Go functions and GoGo handles the rest — generating a fully-featured command-line interface automatically.
+
+GoGo solves the problem of repetitive CLI scaffolding for project automation. Whether it's build scripts, deployment tasks, or developer tooling, GoGo turns function signatures into typed, documented commands with zero ceremony.
+
+**Business Domains**: 4
+
+---
+
+## Executive Summary
+
+GoGo enables Go developers to create and run project automation tasks instantly from function definitions. The system handles:
+
+1. **Workspace Setup** - Scaffolding new task workspaces so developers can start writing tasks immediately
+2. **Task Authoring** - Converting plain Go functions into runnable commands with automatic argument handling
+3. **Task Discovery** - Browsing and understanding all available tasks in a project
+4. **Task Execution** - Running tasks with arguments, smart caching, and build optimization
+
+---
+
+## Business Domains
+
+### [01. Workspace Setup](./01-workspace-setup.md)
+Developers can initialize a new GoGo workspace in any project with a single command. GoGo creates the necessary folder structure and example tasks so developers can start writing automation immediately.
+- Initialize a new task workspace
+- Generate example tasks as starting templates
+- Configure workspace dependencies automatically
+
+### [02. Task Authoring](./02-task-authoring.md)
+Developers write standard Go functions following simple conventions, and GoGo automatically recognizes them as runnable tasks. Function names become command names, parameters become typed arguments, and comments become help text.
+- Write functions that automatically become CLI commands
+- Define typed arguments (text, numbers, true/false values)
+- Add descriptions and documentation through code comments
+- Access task context for richer interactions
+
+### [03. Task Discovery](./03-task-discovery.md)
+Developers can browse all available tasks in a project, see their descriptions and expected arguments, and understand what each task does — all from the command line.
+- List all available tasks with descriptions
+- View argument requirements for any task
+- See tasks from anywhere within a project directory tree
+
+### [04. Task Execution](./04-task-execution.md)
+Developers run tasks by name, passing arguments either positionally or by name. GoGo compiles tasks into fast binaries, caches them intelligently, and only rebuilds when source files change.
+- Run tasks with positional or named arguments
+- Automatic smart caching avoids unnecessary rebuilds
+- Force rebuild when needed
+- Pre-build binaries for faster execution
+- Optimize builds for distribution
+
+---
+
+## Core Concepts
+
+### Task
+A runnable unit of automation. Each task corresponds to a single Go function that GoGo can execute from the command line. Tasks have a name, optional description, and zero or more arguments.
+
+### Workspace
+A designated folder within a project (typically `.gogo`) that contains task definitions. GoGo searches for this folder starting from the current directory and walking up the directory tree, similar to how version control tools find their configuration.
+
+### Argument
+A value that a task accepts from the command line. Arguments are strongly typed — they can be text, whole numbers, decimal numbers, or true/false values. GoGo automatically validates that provided values match the expected type.
+
+### Task Binary
+A compiled, cached version of the task runner. GoGo generates and compiles task definitions into a single binary that executes quickly. The binary is cached and reused until task definitions change.
+
+---
+
+## Key Workflows
+
+### Starting a New Project with Tasks
+```
+1. Developer runs the initialization command in their project
+2. GoGo creates a task workspace folder with example tasks
+3. GoGo sets up necessary dependencies automatically
+4. Developer edits the example tasks or writes new ones
+5. Developer runs tasks immediately — no additional setup needed
+```
+
+### Writing and Running a New Task
+```
+1. Developer creates a new function in the task workspace
+2. Developer gives the function a descriptive name and adds a comment
+3. Developer adds typed parameters for any inputs needed
+4. Developer runs the task by name from anywhere in the project
+5. GoGo compiles the task, caches the binary, and executes it
+```
+
+### Running an Existing Task
+```
+1. Developer lists available tasks to find the right one
+2. Developer sees task descriptions and argument requirements
+3. Developer runs the task, passing arguments by position or name
+4. GoGo checks if a cached build exists and is up to date
+5. If cache is fresh, executes immediately; otherwise rebuilds first
+```
+
+---
+
+## User Types
+
+### Go Developer
+- **Description**: A software developer working in a Go project who needs to automate repetitive tasks like building, testing, deploying, or managing infrastructure.
+- **Primary Activities**: Writing task functions, running tasks from the command line, browsing available tasks.
+- **Access Level**: Full access to all GoGo capabilities. All operations are local to the developer's machine.
+
+### Mage User (Migration Path)
+- **Description**: A developer currently using the Mage task runner who wants to switch to GoGo. GoGo supports Mage-compatible workspace folders for easier migration.
+- **Primary Activities**: Running existing tasks through GoGo, gradually adopting GoGo-specific features.
+- **Access Level**: Full access. GoGo recognizes Mage workspace folders alongside its own.
+
+---
+
+## Access Model
+
+GoGo is a local developer tool with no multi-user access model. All operations run on the developer's own machine with their own file system permissions. There is no authentication, authorization, or data separation — the tool operates entirely within the developer's local project context.
+
+---
+
+## Files in This Specification
+
+```
+specs/
+├── README.md                    # This file
+├── inventory.md                 # Complete capability inventory
+├── 01-workspace-setup.md        # Workspace initialization and scaffolding
+├── 02-task-authoring.md         # Writing tasks as Go functions
+├── 03-task-discovery.md         # Browsing and understanding tasks
+└── 04-task-execution.md         # Running tasks and build management
+```
+
+Note: All files are in a flat structure (no subfolders) for compatibility with systems that don't support nested directories.
+
+---
+
+## Version Information
+
+- **Generated**: 2026-03-23
+- **Source**: GoGo v0.1.0 codebase audit

--- a/history/specs/inventory.md
+++ b/history/specs/inventory.md
@@ -1,0 +1,84 @@
+# GoGo - Capability Inventory
+
+This document provides a comprehensive list of all capabilities in GoGo.
+
+## Summary Statistics
+
+- **Total Capabilities**: 18
+- **Breakdown by Domain**:
+  - Workspace Setup: 3 capabilities
+  - Task Authoring: 6 capabilities
+  - Task Discovery: 4 capabilities
+  - Task Execution: 5 capabilities
+
+---
+
+## DOMAIN: Workspace Setup
+
+**Purpose**: Enables developers to quickly scaffold a new task workspace in any project.
+
+| # | Capability | Description | Who Can Use |
+|---|---|---|---|
+| 1 | Initialize a workspace | Create a new task folder with starter configuration in the current project | Go Developer |
+| 2 | Generate example tasks | Scaffold example task files that demonstrate common patterns | Go Developer |
+| 3 | Auto-configure dependencies | Automatically set up the workspace so tasks can reference the GoGo toolkit | Go Developer |
+
+---
+
+## DOMAIN: Task Authoring
+
+**Purpose**: Enables developers to write plain Go functions that GoGo recognizes and converts into runnable CLI commands.
+
+### Function Conventions
+
+| # | Capability | Description | Who Can Use |
+|---|---|---|---|
+| 1 | Define a task as a function | Write an exported function and GoGo automatically treats it as a runnable task | Go Developer |
+| 2 | Add typed arguments | Define function parameters using text, number, decimal, or true/false types and GoGo generates typed CLI arguments | Go Developer |
+| 3 | Document tasks with comments | Write a comment above a function and GoGo uses it as the task's help text and description | Go Developer |
+| 4 | Signal success or failure | Return an error from a function to indicate task failure, or return nothing to indicate success | Go Developer |
+
+### Advanced Authoring
+
+| # | Capability | Description | Who Can Use |
+|---|---|---|---|
+| 5 | Access task context | Use a special first parameter to access task metadata, configure argument details, and set allowed values | Go Developer |
+| 6 | Organize tasks across files | Split tasks across multiple files in the workspace folder for better organization | Go Developer |
+
+---
+
+## DOMAIN: Task Discovery
+
+**Purpose**: Enables developers to browse and understand all available tasks without reading source code.
+
+| # | Capability | Description | Who Can Use |
+|---|---|---|---|
+| 1 | List all available tasks | View a formatted list of all tasks with their short descriptions | Go Developer |
+| 2 | View task arguments | See what arguments a task expects, including types and defaults | Go Developer |
+| 3 | Discover tasks from subdirectories | Run GoGo from any subdirectory and it finds the nearest task workspace by walking up the directory tree | Go Developer |
+| 4 | View version and build details | Check which version of GoGo is installed and see detailed build information | Go Developer |
+
+---
+
+## DOMAIN: Task Execution
+
+**Purpose**: Enables developers to run tasks with arguments, leveraging smart caching for fast repeated execution.
+
+| # | Capability | Description | Who Can Use |
+|---|---|---|---|
+| 1 | Run a task with arguments | Execute any task by name, passing arguments either by position or by name | Go Developer |
+| 2 | Benefit from smart caching | GoGo tracks source file changes and reuses compiled binaries when nothing has changed | Go Developer |
+| 3 | Force a fresh rebuild | Bypass the cache and force GoGo to recompile tasks from scratch | Go Developer |
+| 4 | Pre-build task binaries | Compile tasks ahead of time so they execute instantly when needed | Go Developer |
+| 5 | Build optimized binaries | Create smaller, optimized binaries suitable for distribution or deployment | Go Developer |
+
+---
+
+## Domain Groupings for Business Specification
+
+The capabilities can be logically grouped into these business domains:
+
+1. **Workspace Setup** - Getting started with GoGo in a new or existing project
+2. **Task Authoring** - Writing and documenting tasks as Go functions
+3. **Task Discovery** - Browsing, searching, and understanding available tasks
+4. **Task Execution** - Running tasks, caching builds, and optimizing performance

--- a/pkg/sh/sh.go
+++ b/pkg/sh/sh.go
@@ -116,14 +116,16 @@ func (e *Executor) String() (string, error) {
 }
 
 // RunWithWriters executes the command and writes the output to the provided writers
-// If stdOut or stdErr are nil, they are not used.
+// If stdOut or stdErr are nil, they default to os.Stdout and os.Stderr respectively.
 func (e *Executor) RunWithWriters(stdOut, errOut io.Writer) error {
 	if stdOut == nil {
 		stdOut = os.Stdout
 	}
 	if errOut == nil {
-		e.stdErr = errOut
+		errOut = os.Stderr
 	}
+	e.stdOut = stdOut
+	e.stdErr = errOut
 	return e.Run()
 }
 
@@ -174,7 +176,7 @@ func (e *Executor) Run() error {
 	}
 	c.Env = e.env
 	c.Stdout = e.stdOut
-	c.Stderr = e.stdOut
+	c.Stderr = e.stdErr
 	c.Stdin = e.stdIn
 
 	err := c.Run()

--- a/pkg/sh/sh_test.go
+++ b/pkg/sh/sh_test.go
@@ -1,0 +1,205 @@
+package sh
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestShSuite(t *testing.T) {
+	suite.Run(t, new(ShTestSuite))
+}
+
+type ShTestSuite struct {
+	suite.Suite
+}
+
+// --- EnvMapToEnv (T003) ---
+
+func (s *ShTestSuite) TestEnvMapToEnv_WithEntries() {
+	env := map[string]string{
+		"FOO": "bar",
+		"BAZ": "qux",
+	}
+	result := EnvMapToEnv(env)
+	assert.Len(s.T(), result, 2)
+	assert.Contains(s.T(), result, "FOO=bar")
+	assert.Contains(s.T(), result, "BAZ=qux")
+}
+
+func (s *ShTestSuite) TestEnvMapToEnv_Empty() {
+	result := EnvMapToEnv(map[string]string{})
+	assert.Empty(s.T(), result)
+}
+
+// --- Constructors and Builder Methods (T004) ---
+
+func (s *ShTestSuite) TestCmd_SingleArg() {
+	out, err := Cmd("echo", "hello").StdOut()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "hello\n", out)
+}
+
+func (s *ShTestSuite) TestCmd_MultipleArgs() {
+	out, err := Cmd("echo", "hello", "world").StdOut()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "hello world\n", out)
+}
+
+func (s *ShTestSuite) TestCmdWithCtx() {
+	ctx := context.Background()
+	out, err := CmdWithCtx(ctx, "echo", "ctx-test").StdOut()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "ctx-test\n", out)
+}
+
+func (s *ShTestSuite) TestDir() {
+	tmpDir := s.T().TempDir()
+	out, err := Cmd("pwd").Dir(tmpDir).StdOut()
+	assert.NoError(s.T(), err)
+	assert.Contains(s.T(), strings.TrimSpace(out), tmpDir)
+}
+
+func (s *ShTestSuite) TestSetArgs() {
+	out, err := Cmd("echo").SetArgs("set-args-test").StdOut()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "set-args-test\n", out)
+}
+
+func (s *ShTestSuite) TestSetEnv() {
+	// SetEnv replaces the entire environment, so only our var should exist
+	out, err := Cmd("env").SetEnv([]string{"MY_TEST_VAR=set-env-value"}).StdOut()
+	assert.NoError(s.T(), err)
+	assert.Contains(s.T(), out, "MY_TEST_VAR=set-env-value")
+}
+
+func (s *ShTestSuite) TestAddEnv() {
+	out, err := Cmd("env").AddEnv([]string{"ADDED_VAR=added-value"}).StdOut()
+	assert.NoError(s.T(), err)
+	assert.Contains(s.T(), out, "ADDED_VAR=added-value")
+}
+
+func (s *ShTestSuite) TestStdin() {
+	input := "stdin-test-data"
+	out, err := Cmd("cat").Stdin(strings.NewReader(input)).StdOut()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), input, out)
+}
+
+// --- Command Parsing (T005) ---
+
+func (s *ShTestSuite) TestRun_SingleStringWithSpaces() {
+	out, err := Cmd("echo hello").StdOut()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "hello\n", out)
+}
+
+func (s *ShTestSuite) TestRun_VariadicArgs() {
+	out, err := Cmd("echo", "variadic", "args").StdOut()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "variadic args\n", out)
+}
+
+func (s *ShTestSuite) TestRun_CommandWithSpacesAndSetArgs() {
+	// When command has spaces AND SetArgs is called, parsed command parts
+	// are prepended to SetArgs values
+	out, err := Cmd("echo hello").SetArgs("world").StdOut()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "hello world\n", out)
+}
+
+func (s *ShTestSuite) TestRun_QuotedStringsInSingleCommand() {
+	out, err := Cmd("echo 'hello world'").StdOut()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "hello world\n", out)
+}
+
+// --- Execution and Output Capture (T006) ---
+
+func (s *ShTestSuite) TestRun_Success() {
+	err := Cmd("true").Run()
+	assert.NoError(s.T(), err)
+}
+
+func (s *ShTestSuite) TestRun_Failure() {
+	err := Cmd("false").Run()
+	assert.Error(s.T(), err)
+}
+
+func (s *ShTestSuite) TestStdOut_CapturesStdoutOnly() {
+	// StdOut should capture stdout; stderr goes elsewhere
+	out, err := Cmd("echo", "stdout-test").StdOut()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "stdout-test\n", out)
+}
+
+func (s *ShTestSuite) TestString_CapturesCombinedOutput() {
+	// String captures both stdout and stderr into one buffer
+	// Use sh -c to write to both stdout and stderr
+	out, err := Cmd("sh", "-c", "echo out; echo err >&2").String()
+	assert.NoError(s.T(), err)
+	assert.Contains(s.T(), out, "out")
+	assert.Contains(s.T(), out, "err")
+}
+
+func (s *ShTestSuite) TestRunWithWriters_CustomWriters() {
+	var stdout, stderr bytes.Buffer
+	err := Cmd("sh", "-c", "echo out; echo err >&2").RunWithWriters(&stdout, &stderr)
+	assert.NoError(s.T(), err)
+	assert.Contains(s.T(), stdout.String(), "out")
+	assert.Contains(s.T(), stderr.String(), "err")
+}
+
+func (s *ShTestSuite) TestRunWithWriters_NilDefaultsToStdoutStderr() {
+	// When nil is passed, should not panic and should execute successfully
+	err := Cmd("true").RunWithWriters(nil, nil)
+	assert.NoError(s.T(), err)
+}
+
+func (s *ShTestSuite) TestRunAndStream() {
+	// RunAndStream writes to os.Stdout/os.Stderr — just verify no error
+	err := Cmd("echo", "stream-test").RunAndStream()
+	assert.NoError(s.T(), err)
+}
+
+// --- Context Cancellation (T007) ---
+
+func (s *ShTestSuite) TestCmdWithCtx_Cancellation() {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := CmdWithCtx(ctx, "sleep", "10").Run()
+	assert.Error(s.T(), err)
+}
+
+// --- DetermineWidth (T008) ---
+
+func (s *ShTestSuite) TestDetermineWidth_NotTerminal() {
+	// In a test environment, stdout is not a terminal
+	width := DetermineWidth(false)
+	assert.Equal(s.T(), -1, width)
+}
+
+// --- Edge Cases (T008) ---
+
+func (s *ShTestSuite) TestRun_NonExistentDir() {
+	err := Cmd("echo", "test").Dir("/nonexistent/path/that/does/not/exist").Run()
+	assert.Error(s.T(), err)
+}
+
+func (s *ShTestSuite) TestRun_EmptyCommand() {
+	err := Cmd("").Run()
+	assert.Error(s.T(), err)
+}
+
+func (s *ShTestSuite) TestSetPrintFinalCommand() {
+	// Verify SetPrintFinalCommand can be set and command still executes
+	out, err := Cmd("echo", "print-test").SetPrintFinalCommand(true).StdOut()
+	assert.NoError(s.T(), err)
+	assert.Contains(s.T(), out, "print-test")
+}

--- a/scenarios/aliased/go.mod
+++ b/scenarios/aliased/go.mod
@@ -4,7 +4,7 @@ go 1.23.4
 
 replace github.com/2bit-software/gogo/pkg/gogo => ./../../pkg/gogo
 
-require github.com/2bit-software/gogo/pkg/gogo v0.0.0-20250407172223-9480d9c1a1ad
+require github.com/2bit-software/gogo/pkg/gogo v0.0.0-20260328181151-f681de3ab816
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect


### PR DESCRIPTION
## Summary
- Fix two bugs in `pkg/sh` where stderr was completely broken: `Run()` wired `c.Stderr` to `e.stdOut` instead of `e.stdErr`, and `RunWithWriters` never assigned writers to the executor
- Add 26 unit tests covering all 15 exported symbols — constructors, builder methods, command parsing, output capture, context cancellation, environment handling, and edge cases
- Zero test coverage → full coverage of the public API

## Test Plan
- [x] 26 unit tests pass in `pkg/sh` (`go test -v -count=1 ./pkg/sh/...`)
- [x] All existing tests pass with no regressions (`go test -count=1 ./pkg/...`)
- [x] Pre-commit hooks pass (lint + full test suite)
- [x] `RunWithWriters` correctly routes stdout/stderr to separate custom writers
- [x] Context cancellation terminates long-running commands

Resolves DEV-162

🤖 Generated with [Claude Code](https://claude.com/claude-code)