### PR TITLE
fix(version): normalize semver inputs to prevent silent comparison failures

### DIFF
--- a/history/69c86b1f-bug-dev-166-fix-version-test-logic/INITIATIVE.md
+++ b/history/69c86b1f-bug-dev-166-fix-version-test-logic/INITIATIVE.md
@@ -1,0 +1,48 @@
+# Initiative: dev-166-fix-version-test-logic
+
+**Type**: bug
+**Status**: completed
+**Created**: 2026-03-28
+**ID**: 69c86b1f-bug-dev-166-fix-version-test-logic
+
+## Steps
+
+| Step | Status | Updated |
+|------|--------|--------|
+| investigate | completed | 2026-03-28 17:01 |
+| fix | completed | 2026-03-28 17:04 |
+| verify | completed | 2026-03-28 17:06 |
+
+## Source
+
+**Linear Ticket**: [DEV-166](https://linear.app/heinsight/issue/DEV-166/fix-version-testgo-logic-error-and-improve-coverage)
+**Title**: Fix version_test.go logic error and improve coverage
+
+## Description
+
+<!-- Add a description of this initiative -->
+
+## Goals
+
+<!-- Define the goals for this initiative -->
+
+## Progress
+
+<!-- Track progress here -->
+
+## Completion
+
+**Completed**: 2026-03-28
+**Duration**: Same day
+
+### Outcomes
+- Bug: Fixed `meetsGoVersionHelper` to normalize "v" prefix and validate semver inputs — Complete
+- Bug: Fixed incorrect test assertion at `version_test.go:51` (`True` → `False`) — Complete
+- Coverage: Added 8 new test cases (edge cases + `MeetsGoVersion` integration tests) — Complete
+
+### Files Changed
+- `pkg/version/version.go` — Input normalization and validation in `meetsGoVersionHelper`
+- `pkg/version/version_test.go` — Fixed assertion, added `NoError` checks, 8 new tests
+
+### Notes
+Root cause was `semver.Compare` treating strings without "v" prefix as invalid, silently returning wrong results. Production caller was unaffected (uses "v" prefix) but tests were passing for the wrong reason.

--- a/history/69c86b1f-bug-dev-166-fix-version-test-logic/bugs/001-version-test-logic-error/classification.md
+++ b/history/69c86b1f-bug-dev-166-fix-version-test-logic/bugs/001-version-test-logic-error/classification.md
@@ -1,0 +1,20 @@
+# Classification
+
+## Type: Implementation Error
+
+## Evidence
+
+1. **`meetsGoVersionHelper` does not validate inputs**: The function silently accepts strings without the required "v" prefix, producing incorrect results. The `semver.Compare` contract requires canonical semver strings starting with "v".
+
+2. **Test uses wrong input format**: Tests pass `"1.24.0"` instead of `"v1.24.0"`, triggering the invalid-string code path in `semver.Compare`.
+
+3. **Test assertion is wrong**: Line 51 asserts `true` when the semantically correct answer is `false` (Go 1.23.2 does not meet minimum 1.24.0).
+
+## Two Interacting Bugs
+
+| Bug | Location | Type |
+|-----|----------|------|
+| No input normalization in `meetsGoVersionHelper` | `version.go:30-34` | Implementation defect |
+| Wrong assertion + wrong test input format | `version_test.go:46-52` | Test defect |
+
+The implementation defect causes the test defect to go undetected — fixing either one in isolation would expose the other.

--- a/history/69c86b1f-bug-dev-166-fix-version-test-logic/bugs/001-version-test-logic-error/fix-plan.md
+++ b/history/69c86b1f-bug-dev-166-fix-version-test-logic/bugs/001-version-test-logic-error/fix-plan.md
@@ -1,0 +1,65 @@
+# Fix Plan
+
+## Changes Required
+
+### 1. Normalize inputs in `meetsGoVersionHelper` (`pkg/version/version.go`)
+
+Add "v" prefix normalization so callers don't need to know about `semver.Compare`'s requirements:
+
+```go
+func meetsGoVersionHelper(required, current string) (bool, error) {
+    if !strings.HasPrefix(required, "v") {
+        required = "v" + required
+    }
+    if !strings.HasPrefix(current, "v") {
+        current = "v" + current
+    }
+    if !semver.IsValid(required) {
+        return false, fmt.Errorf("invalid required version: %s", required)
+    }
+    if !semver.IsValid(current) {
+        return false, fmt.Errorf("invalid current version: %s", current)
+    }
+    compareResult := semver.Compare(required, current)
+    return compareResult <= 0, nil
+}
+```
+
+### 2. Fix test assertion (`pkg/version/version_test.go:51`)
+
+Change `assert.True` to `assert.False` and add `assert.NoError` for consistency:
+
+```go
+func (s *VersionTestSuite) TestGoVersionLowerThan124() {
+    str := "go version go1.23.2 linux/amd64"
+    version, err := getGoVersionString(str)
+    assert.NoError(s.T(), err)
+    result, err := meetsGoVersionHelper("1.24.0", version)
+    assert.NoError(s.T(), err)
+    assert.False(s.T(), result)
+}
+```
+
+### 3. Add edge case tests (`pkg/version/version_test.go`)
+
+- Same version (e.g., 1.24.0 vs 1.24.0) → `true`
+- Patch version difference (1.24.1 vs 1.24.0 required) → `true`
+- Required with "v" prefix → still works
+- Invalid version string → returns error
+- Pre-release versions if applicable
+
+### 4. Add `MeetsGoVersion` test (if feasible)
+
+`MeetsGoVersion` depends on `sh.Cmd("go version")`. Testing options:
+- **Option A**: Test against the actual Go runtime (integration-style) — simplest, verifies real behavior
+- **Option B**: Refactor to inject the command executor — more testable but scope creep
+
+Recommend **Option A**: call `MeetsGoVersion("v1.0.0")` (should return `true` since any modern Go meets 1.0) and `MeetsGoVersion("v99.0.0")` (should return `false`).
+
+## Verification
+
+After applying fixes:
+1. `TestGoVersionLowerThan124` should pass with `assert.False`
+2. All existing tests should still pass
+3. New edge case tests should pass
+4. `go test -v -run "TestVersionSuite" -count=1 ./pkg/version/`

--- a/history/69c86b1f-bug-dev-166-fix-version-test-logic/bugs/001-version-test-logic-error/investigation.md
+++ b/history/69c86b1f-bug-dev-166-fix-version-test-logic/bugs/001-version-test-logic-error/investigation.md
@@ -1,0 +1,45 @@
+# Investigation
+
+## Execution Flow
+
+### `meetsGoVersionHelper(required, current string) (bool, error)`
+
+1. Calls `semver.Compare(required, current)`
+2. Returns `compareResult <= 0` (i.e., required <= current means version is sufficient)
+
+### `getGoVersionString(version string) (string, error)`
+
+1. Parses `"go version go1.XX.Y os/arch"` format
+2. Strips `"go"` prefix, prepends `"v"` → returns `"v1.XX.Y"`
+
+### `MeetsGoVersion(required string) (bool, error)`
+
+1. Runs `go version` via `sh.Cmd`
+2. Parses output with `getGoVersionString` → gets `"v1.XX.Y"`
+3. Passes `required` (as-is) and parsed current to `meetsGoVersionHelper`
+
+## The Bug
+
+`semver.Compare` requires both arguments to have a `"v"` prefix. Strings without `"v"` are invalid and always compare less-than valid strings.
+
+### In Tests
+
+Tests pass `"1.24.0"` (no "v") as `required`. `getGoVersionString` returns `"v1.XX.Y"` (with "v"). Since `"1.24.0"` is invalid:
+
+| Test | required | current | Compare result | Function returns | Correct answer |
+|------|----------|---------|---------------|-----------------|---------------|
+| HigherThan124 | "1.24.0" | "v1.25.0" | -1 | true | true |
+| Exactly124 | "1.24.0" | "v1.24.0" | -1 | true | true |
+| LowerThan124 | "1.24.0" | "v1.23.2" | -1 | **true** | **false** |
+
+All three return `true` because the invalid string always compares less-than. Tests 1 and 2 pass by accident.
+
+### In Production
+
+The sole caller (`pkg/gadgets/init.go:176`) passes `REQUIRED_VERSION = "v1.24.0"` — with the "v" prefix. So production comparisons work correctly. The bug is **latent in production** but **active in tests**.
+
+## Impact Assessment
+
+- **Production risk**: Low — the only caller uses the correct "v" prefix format
+- **Test reliability**: Broken — tests pass for the wrong reason, providing false confidence
+- **API fragility**: High — any new caller that omits "v" will get silently wrong results

--- a/history/69c86b1f-bug-dev-166-fix-version-test-logic/bugs/001-version-test-logic-error/report.md
+++ b/history/69c86b1f-bug-dev-166-fix-version-test-logic/bugs/001-version-test-logic-error/report.md
@@ -1,0 +1,22 @@
+# Bug Report: version_test.go logic error and MeetsGoVersion always returns true
+
+## Source
+
+**Linear Ticket**: [DEV-166](https://linear.app/heinsight/issue/DEV-166/fix-version-testgo-logic-error-and-improve-coverage)
+
+## Symptoms
+
+1. **Test assertion error (line 51)**: `TestGoVersionLowerThan124` tests Go 1.23.2 against a minimum requirement of 1.24.0 and asserts `true`. Go 1.23.2 does NOT meet 1.24.0, so this should assert `false`.
+
+2. **`MeetsGoVersion()` always returns `true`**: The public function passes `required` without a "v" prefix to `meetsGoVersionHelper`, but `getGoVersionString` returns `current` with a "v" prefix. The `semver.Compare` function treats strings without "v" as invalid, and invalid strings always sort less-than valid ones. This means `semver.Compare(required, current)` always returns `-1`, and `-1 <= 0` is always `true`.
+
+3. **No tests for `MeetsGoVersion()`**: The public function is untested — only internal helpers have coverage.
+
+## Affected Files
+
+- `pkg/version/version.go` — `meetsGoVersionHelper()` and `MeetsGoVersion()`
+- `pkg/version/version_test.go` — incorrect assertion and missing coverage
+
+## Impact
+
+Any code relying on `MeetsGoVersion()` to gate behavior on Go version will always pass, even if the installed Go version is too old.

--- a/history/69c86b1f-bug-dev-166-fix-version-test-logic/bugs/001-version-test-logic-error/reproduction.md
+++ b/history/69c86b1f-bug-dev-166-fix-version-test-logic/bugs/001-version-test-logic-error/reproduction.md
@@ -1,0 +1,42 @@
+# Reproduction
+
+## Environment
+
+- Go 1.24+
+- `golang.org/x/mod/semver` package
+
+## Steps
+
+1. Run `go test -v -run "TestVersionSuite" -count=1 ./pkg/version/`
+2. Observe all tests pass, including `TestGoVersionLowerThan124`
+3. `TestGoVersionLowerThan124` checks if Go 1.23.2 meets a requirement of 1.24.0 — it asserts `true`, but the correct answer is `false`
+
+## Root Cause Verification
+
+```go
+semver.IsValid("1.24.0")  // false — missing "v" prefix
+semver.IsValid("v1.24.0") // true
+
+// With invalid "required" (no "v"), Compare always returns -1:
+semver.Compare("1.24.0", "v1.23.2") // -1 (should be +1)
+semver.Compare("1.24.0", "v1.24.0") // -1 (should be 0)
+semver.Compare("1.24.0", "v1.25.0") // -1 (correct by accident)
+```
+
+Because `meetsGoVersionHelper` returns `compareResult <= 0`, and the result is always `-1`, the function always returns `true`.
+
+## Failing Test (corrected assertion)
+
+The existing test at `pkg/version/version_test.go:51` should assert `false`:
+
+```go
+func (s *VersionTestSuite) TestGoVersionLowerThan124() {
+    str := "go version go1.23.2 linux/amd64"
+    version, err := getGoVersionString(str)
+    assert.NoError(s.T(), err)
+    result, err := meetsGoVersionHelper("1.24.0", version)
+    assert.False(s.T(), result) // <-- currently asserts True
+}
+```
+
+Changing this assertion alone will **still pass** because the implementation bug (missing "v" prefix on `required`) masks the test bug. Both must be fixed together.

--- a/history/69c86b1f-bug-dev-166-fix-version-test-logic/research.md
+++ b/history/69c86b1f-bug-dev-166-fix-version-test-logic/research.md
@@ -1,0 +1,47 @@
+---
+status: template
+updated:
+---
+
+# Research: [Feature Name]
+
+## Executive Summary
+
+<!-- 2-3 sentence overview of the research findings - to be filled during research phase -->
+
+## Findings
+
+### Codebase Context
+
+<!-- Findings from exploring the existing codebase -->
+
+- Architecture patterns
+- Relevant existing code
+- Dependencies and constraints
+
+### Domain Knowledge
+
+<!-- Findings from domain research and best practices -->
+
+- Industry standards
+- Best practices
+- Similar implementations
+
+## Decision Points
+
+<!-- Decisions that need to be made during specification -->
+
+- [ ] **D1**: [Decision needed] - Options: A, B, C
+
+## Recommendations
+
+<!-- Recommended approaches with rationale -->
+
+1. [Recommendation with reasoning]
+
+## Sources
+
+<!-- List all sources referenced -->
+
+- [Source 1]
+- [Source 2]

--- a/history/69c86b1f-bug-dev-166-fix-version-test-logic/spec.md
+++ b/history/69c86b1f-bug-dev-166-fix-version-test-logic/spec.md
@@ -1,0 +1,152 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Input**: User description: "$ARGUMENTS"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]
+
+## Testing Requirements *(mandatory)*
+
+<!--
+  IMPORTANT: This section defines what tests are required for this feature.
+  Every functional requirement (FR) must have at least one associated test.
+
+  Testing Strategy (Integration-First):
+  - Prefer integration tests at module boundaries
+  - Use E2E tests for critical user journeys
+  - Add unit tests only for complex pure functions with many edge cases
+  - Test contracts/behavior, not implementation details
+
+  If this feature requires NO tests (e.g., documentation-only change):
+  - Replace this section with: "Testing Requirements: None - [justification]"
+  - The justification must explain why no tests are needed
+-->
+
+### Test Strategy
+
+[Describe the testing approach for this feature:
+- What types of tests will be written?
+- What test frameworks/tools will be used?
+- Any special testing considerations?]
+
+### FR to Test Mapping
+
+| FR | Test Type | Description |
+|----|-----------|-------------|
+| FR-001 | Integration | [What the test verifies] |
+| FR-002 | E2E | [What the test verifies] |
+| FR-003 | Unit | [What the test verifies - only if complex logic] |
+
+### Edge Case Coverage
+
+- [Edge case 1] → [How it will be tested]
+- [Edge case 2] → [How it will be tested]

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,7 +28,18 @@ func MeetsGoVersion(required string) (bool, error) {
 }
 
 func meetsGoVersionHelper(required, current string) (bool, error) {
-	// Compare version using semver library
+	if !strings.HasPrefix(required, "v") {
+		required = "v" + required
+	}
+	if !strings.HasPrefix(current, "v") {
+		current = "v" + current
+	}
+	if !semver.IsValid(required) {
+		return false, fmt.Errorf("invalid required version: %s", required)
+	}
+	if !semver.IsValid(current) {
+		return false, fmt.Errorf("invalid current version: %s", current)
+	}
 	compareResult := semver.Compare(required, current)
 	return compareResult <= 0, nil
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -32,6 +32,7 @@ func (s *VersionTestSuite) TestGoVersionHigherThan124() {
 	version, err := getGoVersionString(str)
 	assert.NoError(s.T(), err)
 	result, err := meetsGoVersionHelper("1.24.0", version)
+	assert.NoError(s.T(), err)
 	assert.True(s.T(), result)
 }
 
@@ -40,6 +41,7 @@ func (s *VersionTestSuite) TestGoVersion124() {
 	version, err := getGoVersionString(str)
 	assert.NoError(s.T(), err)
 	result, err := meetsGoVersionHelper("1.24.0", version)
+	assert.NoError(s.T(), err)
 	assert.True(s.T(), result)
 }
 
@@ -48,7 +50,66 @@ func (s *VersionTestSuite) TestGoVersionLowerThan124() {
 	version, err := getGoVersionString(str)
 	assert.NoError(s.T(), err)
 	result, err := meetsGoVersionHelper("1.24.0", version)
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), result)
+}
+
+func (s *VersionTestSuite) TestGoVersionSameVersion() {
+	str := "go version go1.24.0 linux/amd64"
+	version, err := getGoVersionString(str)
+	assert.NoError(s.T(), err)
+	result, err := meetsGoVersionHelper("1.24.0", version)
+	assert.NoError(s.T(), err)
 	assert.True(s.T(), result)
+}
+
+func (s *VersionTestSuite) TestGoVersionPatchHigher() {
+	str := "go version go1.24.3 linux/amd64"
+	version, err := getGoVersionString(str)
+	assert.NoError(s.T(), err)
+	result, err := meetsGoVersionHelper("1.24.0", version)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), result)
+}
+
+func (s *VersionTestSuite) TestGoVersionPatchLower() {
+	str := "go version go1.24.0 linux/amd64"
+	version, err := getGoVersionString(str)
+	assert.NoError(s.T(), err)
+	result, err := meetsGoVersionHelper("1.24.3", version)
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), result)
+}
+
+func (s *VersionTestSuite) TestGoVersionWithVPrefix() {
+	str := "go version go1.25.0 linux/amd64"
+	version, err := getGoVersionString(str)
+	assert.NoError(s.T(), err)
+	result, err := meetsGoVersionHelper("v1.24.0", version)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), result)
+}
+
+func (s *VersionTestSuite) TestGoVersionInvalidRequired() {
+	_, err := meetsGoVersionHelper("not-a-version", "v1.24.0")
+	assert.Error(s.T(), err)
+}
+
+func (s *VersionTestSuite) TestGoVersionInvalidCurrent() {
+	_, err := meetsGoVersionHelper("v1.24.0", "not-a-version")
+	assert.Error(s.T(), err)
+}
+
+func (s *VersionTestSuite) TestMeetsGoVersionLowRequirement() {
+	result, err := MeetsGoVersion("v1.0.0")
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), result)
+}
+
+func (s *VersionTestSuite) TestMeetsGoVersionHighRequirement() {
+	result, err := MeetsGoVersion("v99.0.0")
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), result)
 }
 
 func (s *VersionTestSuite) TestInvalidVersionFormat() {

--- a/scenarios/aliased/go.mod
+++ b/scenarios/aliased/go.mod
@@ -4,7 +4,7 @@ go 1.23.4
 
 replace github.com/2bit-software/gogo/pkg/gogo => ./../../pkg/gogo
 
-require github.com/2bit-software/gogo/pkg/gogo v0.0.0-20260328191017-faa2212bb1ff
+require github.com/2bit-software/gogo/pkg/gogo v0.0.0-20260328203246-4264e04a022e
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect


### PR DESCRIPTION
## Summary
- `meetsGoVersionHelper` silently returned wrong results when version strings lacked the "v" prefix required by `semver.Compare` — invalid strings always sort below valid ones, making the function always return `true`
- Added "v" prefix normalization and `semver.IsValid` validation so callers don't need to know about semver's prefix requirement
- Fixed incorrect test assertion (`TestGoVersionLowerThan124` asserted `true` for Go 1.23.2 vs 1.24.0 requirement) and added 8 new tests covering edge cases, invalid inputs, and `MeetsGoVersion` integration

## Test Plan
- [x] `TestGoVersionLowerThan124` correctly asserts `false`
- [x] All 12 version tests pass (up from 4)
- [x] `MeetsGoVersion` integration tests pass against real `go version`
- [x] Project builds cleanly
- [x] Pre-commit hooks pass

Resolves DEV-166

🤖 Generated with [Claude Code](https://claude.com/claude-code)